### PR TITLE
Update LogBlockBlockList.java

### DIFF
--- a/src/me/itsatacoshop247/TreeAssist/blocklists/LogBlockBlockList.java
+++ b/src/me/itsatacoshop247/TreeAssist/blocklists/LogBlockBlockList.java
@@ -42,6 +42,7 @@ public class LogBlockBlockList implements BlockList {
 		params.limit = 1;
 		params.loc = block.getLocation();
 		params.needType = true;
+		params.world = block.getWorld();
 
 		try {
 		    for (BlockChange bc : logBlock.getBlockChanges(params)) {


### PR DESCRIPTION
Pass block's world to LB, fixes NPE for world being null when checking the blocks log in LogBlock on block break.
